### PR TITLE
Added getBlockByNumber command

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -11,6 +11,7 @@ var commands = module.exports.commands = [
   , 'getAddressesByAccount'
   , 'getBalance'
   , 'getBlock'
+  , 'getBlockByNumber'
   , 'getBlockCount'
   , 'getBlockHash'
   , 'getBlockCount'


### PR DESCRIPTION
Coin ION has this command. I am sure other coins have this too.

This command lets you get block information by height rather than only by hash